### PR TITLE
Fix references

### DIFF
--- a/docs/Omnidirectional-Cameras.html
+++ b/docs/Omnidirectional-Cameras.html
@@ -5,288 +5,203 @@
 <!--[if gt IE 8]><!--> <html class="no-js" lang="en" > <!--<![endif]-->
 <head>
   <meta charset="utf-8">
-  
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   
   <title>Omni directional cameras &mdash; OmniCV 0.0.1 documentation</title>
-  
 
-  
-  
-  
-  
+  <script type="text/javascript" src="_static/js/modernizr.min.js"></script> 
+  <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
+  <script src="_static/jquery.js"></script>
+  <script src="_static/underscore.js"></script>
+  <script src="_static/doctools.js"></script>
+  <script src="_static/language_data.js"></script>
+  <script type="text/javascript" src="_static/js/theme.js"></script>
 
-  
-  <script type="text/javascript" src="_static/js/modernizr.min.js"></script>
-  
-    
-      <script type="text/javascript" id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
-        <script src="_static/jquery.js"></script>
-        <script src="_static/underscore.js"></script>
-        <script src="_static/doctools.js"></script>
-        <script src="_static/language_data.js"></script>
-    
-    <script type="text/javascript" src="_static/js/theme.js"></script>
-
-    
-
-  
   <link rel="stylesheet" href="_static/css/theme.css" type="text/css" />
   <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
-    <link rel="index" title="Index" href="genindex.html" />
-    <link rel="search" title="Search" href="search.html" />
-    <link rel="next" title="Example for users to understand how to use the library" href="Examples.html" />
-    <link rel="prev" title="Welcome to OmniCV Documentation" href="index.html" /> 
+  <link rel="index" title="Index" href="genindex.html" />
+  <link rel="search" title="Search" href="search.html" />
+  <link rel="next" title="Example for users to understand how to use the library" href="Examples.html" />
+  <link rel="prev" title="Welcome to OmniCV Documentation" href="index.html" /> 
 </head>
 
 <body class="wy-body-for-nav">
-
-   
   <div class="wy-grid-for-nav">
-    
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
       <div class="wy-side-scroll">
         <div class="wy-side-nav-search" >
-          
+          <a href="index.html" class="icon icon-home"> OmniCV <img src="_static/logo.png" class="logo" alt="Logo"/></a>
 
-          
-            <a href="index.html" class="icon icon-home"> OmniCV
-          
-
-          
-            
-            <img src="_static/logo.png" class="logo" alt="Logo"/>
-          
-          </a>
-
-          
-            
-            
-          
-
-          
-<div role="search">
-  <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
-    <input type="text" name="q" placeholder="Search docs" />
-    <input type="hidden" name="check_keywords" value="yes" />
-    <input type="hidden" name="area" value="default" />
-  </form>
-</div>
-
-          
+          <div role="search">
+            <form id="rtd-search-form" class="wy-form" action="search.html" method="get">
+              <input type="text" name="q" placeholder="Search docs" />
+              <input type="hidden" name="check_keywords" value="yes" />
+              <input type="hidden" name="area" value="default" />
+            </form>
+          </div>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
-          
-            
-            
-              
-            
-            
+          <ul class="current">
+            <li class="toctree-l1"><a class="reference internal" href="index.html">Welcome to OmniCV Documentation</a></li>
+            <li class="toctree-l1 current"><a class="reference internal" href="index.html#introduction">Introduction</a>
               <ul class="current">
-<li class="toctree-l1"><a class="reference internal" href="index.html">Welcome to OmniCV Documentation</a></li>
-<li class="toctree-l1 current"><a class="reference internal" href="index.html#introduction">Introduction</a><ul class="current">
-<li class="toctree-l2"><a class="reference internal" href="index.html#objectives-of-the-omnicv-library">Objectives of the OmniCV library</a></li>
-<li class="toctree-l2"><a class="reference internal" href="index.html#output-gallery">Output Gallery</a></li>
-<li class="toctree-l2 current"><a class="reference internal" href="index.html#index-to-theory-examples-application-notes-and-ros-nodes">Index to theory examples , application notes and ROS nodes</a><ul class="current">
-<li class="toctree-l3 current"><a class="current reference internal" href="#">Omni directional cameras</a><ul>
-<li class="toctree-l4"><a class="reference internal" href="#dioptric-cameras-with-a-single-lens">1. Dioptric cameras with a single lens</a></li>
-<li class="toctree-l4"><a class="reference internal" href="#catadioptric-cameras">2. Catadioptric cameras</a></li>
-<li class="toctree-l4"><a class="reference internal" href="#camera-with-two-lens">3. Camera with two lens</a></li>
-<li class="toctree-l4"><a class="reference internal" href="#polydioptric-cameras">4. Polydioptric cameras</a></li>
-<li class="toctree-l4"><a class="reference internal" href="#id1">Back to home page</a></li>
-</ul>
-</li>
-<li class="toctree-l3"><a class="reference internal" href="Examples.html">Example for users to understand how to use the library</a></li>
-<li class="toctree-l3"><a class="reference internal" href="Applications.html">Some application notes or use cases of the library</a></li>
-<li class="toctree-l3"><a class="reference internal" href="ROS_Nodes.html">Documentation for ROS Nodes</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="index.html#installation-guide">Installation guide</a></li>
-<li class="toctree-l1"><a class="reference internal" href="index.html#running-the-tests">Running The Tests</a></li>
-<li class="toctree-l1 current"><a class="current reference internal" href="#">Omni directional cameras</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="#dioptric-cameras-with-a-single-lens">1. Dioptric cameras with a single lens</a></li>
-<li class="toctree-l2"><a class="reference internal" href="#catadioptric-cameras">2. Catadioptric cameras</a></li>
-<li class="toctree-l2"><a class="reference internal" href="#camera-with-two-lens">3. Camera with two lens</a></li>
-<li class="toctree-l2"><a class="reference internal" href="#polydioptric-cameras">4. Polydioptric cameras</a><ul>
-<li class="toctree-l3"><a class="reference internal" href="#references">References</a></li>
-</ul>
-</li>
-<li class="toctree-l2"><a class="reference internal" href="#id1">Back to home page</a></li>
-</ul>
-</li>
-<li class="toctree-l1"><a class="reference internal" href="Examples.html">Example for users to understand how to use the library</a></li>
-<li class="toctree-l1"><a class="reference internal" href="Applications.html">Some application notes or use cases of the library</a></li>
-<li class="toctree-l1"><a class="reference internal" href="ROS_Nodes.html">Documentation for ROS Nodes</a></li>
-</ul>
-
-            
-          
+              <li class="toctree-l2"><a class="reference internal" href="index.html#objectives-of-the-omnicv-library">Objectives of the OmniCV library</a></li>
+              <li class="toctree-l2"><a class="reference internal" href="index.html#output-gallery">Output Gallery</a></li>
+              <li class="toctree-l2 current"><a class="reference internal" href="index.html#index-to-theory-examples-application-notes-and-ros-nodes">Index to theory examples , application notes and ROS nodes</a>
+                <ul class="current">
+                  <li class="toctree-l3 current"><a class="current reference internal" href="#">Omni directional cameras</a>
+                  <ul>
+                    <li class="toctree-l4"><a class="reference internal" href="#dioptric-cameras-with-a-single-lens">1. Dioptric cameras with a single lens</a></li>
+                    <li class="toctree-l4"><a class="reference internal" href="#catadioptric-cameras">2. Catadioptric cameras</a></li>
+                    <li class="toctree-l4"><a class="reference internal" href="#camera-with-two-lens">3. Camera with two lens</a></li>
+                    <li class="toctree-l4"><a class="reference internal" href="#polydioptric-cameras">4. Polydioptric cameras</a></li>
+                    <li class="toctree-l4"><a class="reference internal" href="#id1">Back to home page</a></li>
+                  </ul>
+                </li>
+                <li class="toctree-l3"><a class="reference internal" href="Examples.html">Example for users to understand how to use the library</a></li>
+                <li class="toctree-l3"><a class="reference internal" href="Applications.html">Some application notes or use cases of the library</a></li>
+                <li class="toctree-l3"><a class="reference internal" href="ROS_Nodes.html">Documentation for ROS Nodes</a></li>
+              </ul>
+            </li>
+          </ul>
+          </li>
+          <li class="toctree-l1"><a class="reference internal" href="index.html#installation-guide">Installation guide</a></li>
+          <li class="toctree-l1"><a class="reference internal" href="index.html#running-the-tests">Running The Tests</a></li>
+          <li class="toctree-l1 current"><a class="current reference internal" href="#">Omni directional cameras</a><ul>
+          <li class="toctree-l2"><a class="reference internal" href="#dioptric-cameras-with-a-single-lens">1. Dioptric cameras with a single lens</a></li>
+          <li class="toctree-l2"><a class="reference internal" href="#catadioptric-cameras">2. Catadioptric cameras</a></li>
+          <li class="toctree-l2"><a class="reference internal" href="#camera-with-two-lens">3. Camera with two lens</a></li>
+          <li class="toctree-l2"><a class="reference internal" href="#polydioptric-cameras">4. Polydioptric cameras</a><ul>
+          <li class="toctree-l3"><a class="reference internal" href="#references">References</a></li>
+          </ul>
+          </li>
+          <li class="toctree-l2"><a class="reference internal" href="#id1">Back to home page</a></li>
+          </ul>
+          </li>
+          <li class="toctree-l1"><a class="reference internal" href="Examples.html">Example for users to understand how to use the library</a></li>
+          <li class="toctree-l1"><a class="reference internal" href="Applications.html">Some application notes or use cases of the library</a></li>
+          <li class="toctree-l1"><a class="reference internal" href="ROS_Nodes.html">Documentation for ROS Nodes</a></li>
+          </ul>
         </div>
       </div>
     </nav>
 
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
-
-      
-      <nav class="wy-nav-top" aria-label="top navigation">
-        
+      <nav class="wy-nav-top" aria-label="top navigation">   
           <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-          <a href="index.html">OmniCV</a>
-        
+          <a href="index.html">OmniCV</a>  
       </nav>
-
-
-      <div class="wy-nav-content">
-        
+      <div class="wy-nav-content">      
         <div class="rst-content">
-        
-          
+          <div role="navigation" aria-label="breadcrumbs navigation">
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-<div role="navigation" aria-label="breadcrumbs navigation">
-
-  <ul class="wy-breadcrumbs">
-    
-      <li><a href="index.html">Docs</a> &raquo;</li>
-        
-      <li>Omni directional cameras</li>
-    
-    
-      <li class="wy-breadcrumbs-aside">
-        
-            
-            <a href="_sources/Omnidirectional-Cameras.rst.txt" rel="nofollow"> View page source</a>
-          
-        
-      </li>
-    
-  </ul>
-
-  
-  <hr/>
-</div>
-          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
-           <div itemprop="articleBody">
-            
-  <div class="section" id="omni-directional-cameras">
-<h1>Omni directional cameras<a class="headerlink" href="#omni-directional-cameras" title="Permalink to this headline">¶</a></h1>
-<p>Omnidirectional cameras refer to cameras that have a larger field of view than the normal cameras (more than 180 ° and ideally 360 °). This includes cameras with horizontal 360 ° field of view(FOV) and cameras with FOV spanning a 360 ° horizontal and more than 90 (ideally 180) vertical field of view(FOV).[1] Ever imagined how we can get a 360 ° field of view?</p>
-<p>An omnidirectional camera (from Omni, meaning all) is a camera with a 360 ° field of view in the horizontal plane, or with a visual field that covers a hemisphere or (approximately) the entire sphere. There are designs proposed to achieve a 360 ° degree field of view.</p>
-<div class="section" id="dioptric-cameras-with-a-single-lens">
-<h2>1. Dioptric cameras with a single lens<a class="headerlink" href="#dioptric-cameras-with-a-single-lens" title="Permalink to this headline">¶</a></h2>
-<p>Cameras which use an only special lens to refract light such that the field of view is more than 90 ° vertically and 360 ° horizontally. One common example of such type of camera is a fisheye camera.</p>
-<div class="figure align-center" id="id2" style="width: 400px">
-<a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg" style="width: 200px; height: 200px;" /></a>
-<p class="caption"><span class="caption-text">Figure 1 - Image of a fisheye camera. (source - wikipedia) [3]</span><a class="headerlink" href="#id2" title="Permalink to this image">¶</a></p>
-</div>
-</div>
-<div class="section" id="catadioptric-cameras">
-<h2>2. Catadioptric cameras<a class="headerlink" href="#catadioptric-cameras" title="Permalink to this headline">¶</a></h2>
-<p>Cameras that use a combination of the lens (to refract light) and mirrors (to reflect light) with a normal camera to generate 360 ° horizontal and more than 90 ° vertical field of view.[1]
-Figure 2 is an example of a catadioptric camera.</p>
-<div class="figure align-center" id="id3" style="width: 400px">
-<a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG"><img alt="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG" src="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG" style="width: 200px;" /></a>
-<p class="caption"><span class="caption-text">Figure2 - Example of an omni directional camera using mirrors. (souce-wikipedia ) [2].
-1. Camera
-2. Lower mirror
-3. Aperture
-4. Glass housing
-5. Cover and upper mirro</span><a class="headerlink" href="#id3" title="Permalink to this image">¶</a></p>
-</div>
-</div>
-<div class="section" id="camera-with-two-lens">
-<h2>3. Camera with two lens<a class="headerlink" href="#camera-with-two-lens" title="Permalink to this headline">¶</a></h2>
-<p>Cameras that consist of two fisheye cameras placed facing away from each other and each one has a FOV that can span more than a hemisphere. Images from both cameras are stitched to get the full 360 ° image. This configuration is commonly used in the 360 ° cameras available in the market.</p>
-<div class="figure align-center" id="id4" style="width: 400px">
-<a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg" style="width: 200px; height: 200px;" /></a>
-<p class="caption"><span class="caption-text">Figure 3 - Image of a 360 ° camera with two lenses. (source - wikipedia) [4]</span><a class="headerlink" href="#id4" title="Permalink to this image">¶</a></p>
-</div>
-</div>
-<div class="section" id="polydioptric-cameras">
-<h2>4. Polydioptric cameras<a class="headerlink" href="#polydioptric-cameras" title="Permalink to this headline">¶</a></h2>
-<p>Cameras which consist of more than two cameras with overlapping field of view.[1] One example of such type of camera is the throwing camera “panono”[5]. Image from all the cameras is captured at the same time and then stitched to get the full 360 ° image.</p>
-<div class="figure align-center" id="id5" style="width: 400px">
-<a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg" style="width: 200px; height: 200px;" /></a>
-<p class="caption"><span class="caption-text">Figure 4 - Image of panono polydioptric camera. (source - wikipedia) [6]</span><a class="headerlink" href="#id5" title="Permalink to this image">¶</a></p>
-</div>
-<p><strong>Read</strong> <a class="reference external" href="http://rpg.ifi.uzh.ch/docs/omnidirectional_camera.pdf">this paper</a>. [1] <strong>on Omnidirectional cameras to know more about different ommni directional cameras</strong></p>
-<div class="section" id="references">
-<h3>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h3>
-<p><strong>[1]</strong> Scaramuzza, Davide. (2014).Omnidirectional Camera. Computer Vision: A Reference Guide, Editors: Katsushi Ikeuchi, ISBN: 978-0-387-30771-8 (Print) 978-0-387-31439-6 (Online), Springer, April, 2014</p>
-<p><strong>[2]</strong> <a class="reference external" href="https://en.wikipedia.org/wiki/Omnidirectional_camera">https://en.wikipedia.org/wiki/Omnidirectional_camera</a></p>
-<p><strong>[3]</strong> Figure 1 - <a class="reference external" href="https://commons.wikimedia.org/wiki/File:Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg">https://commons.wikimedia.org/wiki/File:Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg</a></p>
-<p><strong>[4]</strong> Figure 3 - <a class="reference external" href="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg</a></p>
-<p><strong>[5]</strong> Omnidirectional cameras - <a class="reference external" href="https://en.wikipedia.org/wiki/Omnidirectional_camera">https://en.wikipedia.org/wiki/Omnidirectional_camera</a></p>
-</div>
-</div>
-<div class="section" id="id1">
-<h2><a class="reference external" href="index.html">Back to home page</a><a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h2>
-</div>
-</div>
-
-
-           </div>
-           
+            <ul class="wy-breadcrumbs">          
+                <li><a href="index.html">Docs</a> &raquo;</li>  
+                <li>Omni directional cameras</li>
+                <li class="wy-breadcrumbs-aside">
+                      <a href="_sources/Omnidirectional-Cameras.rst.txt" rel="nofollow"> View page source</a>                
+                </li>
+            </ul>
+            <hr/>
           </div>
-          <footer>
-  
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      
-        <a href="Examples.html" class="btn btn-neutral float-right" title="Example for users to understand how to use the library" accesskey="n" rel="next">Next <span class="fa fa-arrow-circle-right"></span></a>
-      
-      
-        <a href="index.html" class="btn btn-neutral float-left" title="Welcome to OmniCV Documentation" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> Previous</a>
-      
-    </div>
-  
+          <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
+            <div itemprop="articleBody">
+              <div class="section" id="omni-directional-cameras">
+                <h1>Omni directional cameras<a class="headerlink" href="#omni-directional-cameras" title="Permalink to this headline">¶</a></h1>
 
-  <hr/>
+                <p>Omnidirectional cameras refer to cameras that have a larger field of view than the normal cameras (more than 180 ° and ideally 360 °). This includes cameras with horizontal 360 ° field of view(FOV) and cameras with FOV spanning a 360 ° horizontal and more than 90 (ideally 180) vertical field of view(FOV).[<a href="#ref1">1</a>][<a href="#ref1">2</a>] Ever imagined how we can get a 360 ° field of view?</p>
 
-  <div role="contentinfo">
-    <p>
-        &copy; Copyright 2020, Kaustubh Sadekar, Leena Vachhani, Abhishek Gupta
+                <p>An omnidirectional camera (from Omni, meaning all) is a camera with a 360 ° field of view in the horizontal plane, or with a visual field that covers a hemisphere or (approximately) the entire sphere. There are designs proposed to achieve a 360 ° degree field of view.</p>
+                
+                <div class="section" id="dioptric-cameras-with-a-single-lens">
+                  <h2>1. Dioptric cameras with a single lens<a class="headerlink" href="#dioptric-cameras-with-a-single-lens" title="Permalink to this headline">¶</a></h2>
 
-    </p>
-  </div>
-  Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>. 
+                  <p>Cameras which use an only special lens to refract light such that the field of view is more than 90 ° vertically and 360 ° horizontally. One common example of such type of camera is a fisheye camera.</p>
 
-</footer>
+                  <div class="figure align-center" id="id2" style="width: 400px">
+                    <a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg/757px-Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg" style="width: 200px; height: 200px;" /></a>
+                    <p class="caption"><span class="caption-text">Figure 1 - Image of a fisheye camera. (source - wikipedia) [<a href="#ref1">3</a>]</span><a class="headerlink" href="#id2" title="Permalink to this image">¶</a></p>
+                  </div>
+                </div>
+                <div class="section" id="catadioptric-cameras">
 
+                  <h2>2. Catadioptric cameras<a class="headerlink" href="#catadioptric-cameras" title="Permalink to this headline">¶</a></h2>
+
+                  <p>Cameras that use a combination of the lens (to refract light) and mirrors (to reflect light) with a normal camera to generate 360° horizontal and more than 90° vertical field of view.[<a href="#ref1">1</a>][<a href="#ref1">2</a>] Figure 2 is an example of a catadioptric camera.</p>
+                  <div class="figure align-center" id="id3" style="width: 400px">
+                    <a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG"><img alt="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG" src="https://upload.wikimedia.org/wikipedia/commons/0/04/Omnidirectional_camera_numbered.PNG" style="width: 200px;" /></a>
+                    <p class="caption"><span class="caption-text">Figure2 - Example of an omni directional camera using mirrors. (souce-wikipedia ) [<a href="#ref1">5</a>].
+                    1. Camera
+                    2. Lower mirror
+                    3. Aperture
+                    4. Glass housing
+                    5. Cover and upper mirro</span><a class="headerlink" href="#id3" title="Permalink to this image">¶</a></p>
+                  </div>
+                </div>
+                <div class="section" id="camera-with-two-lens">
+                <h2>3. Camera with two lens<a class="headerlink" href="#camera-with-two-lens" title="Permalink to this headline">¶</a></h2>
+                <p>Cameras that consist of two fisheye cameras placed facing away from each other and each one has a FOV that can span more than a hemisphere. Images from both cameras are stitched to get the full 360 ° image. This configuration is commonly used in the 360 ° cameras available in the market.</p>
+                <div class="figure align-center" id="id4" style="width: 400px">
+                  <a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg" style="width: 200px; height: 200px;" /></a>
+                  <p class="caption"><span class="caption-text">Figure 3 - Image of a 360 ° camera with two lenses. (source - wikipedia) [<a href="#ref1">4</a>]</span><a class="headerlink" href="#id4" title="Permalink to this image">¶</a></p>
+                </div>
+              </div>
+              <div class="section" id="polydioptric-cameras">
+              <h2>4. Polydioptric cameras<a class="headerlink" href="#polydioptric-cameras" title="Permalink to this headline">¶</a></h2>
+                <p>Cameras which consist of more than two cameras with overlapping field of view.[<a href="#ref1">1</a>][<a href="#ref1">2</a>] One example of such type of camera is the throwing camera “panono”[<a href="#ref1">5</a>]. Image from all the cameras is captured at the same time and then stitched to get the full 360 ° image.</p>
+                <div class="figure align-center" id="id5" style="width: 400px">
+                  <a class="reference internal image-reference" href="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg"><img alt="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/KSG_1750_pK.jpg/627px-KSG_1750_pK.jpg" style="width: 200px; height: 200px;" /></a>
+                  <p class="caption"><span class="caption-text">Figure 4 - Image of panono polydioptric camera. (source - wikipedia) [6]</span><a class="headerlink" href="#id5" title="Permalink to this image">¶</a></p>
+                </div>  
+                <p><strong>Read</strong> <a class="reference external" href="http://rpg.ifi.uzh.ch/docs/omnidirectional_camera.pdf">this paper</a>. [<a href="#ref1">1</a>] <strong>on Omnidirectional cameras to know more about different ommni directional cameras</strong></p>
+
+                <div class="section" id="references">
+                  <h3>References<a class="headerlink" href="#references" title="Permalink to this headline">¶</a></h3>
+
+                  <p id="ref1"><strong>[1]</strong> Scaramuzza, Davide. (2014).Omnidirectional Camera. Available on <a href="https://www.researchgate.net/publication/280671103_Omnidirectional_Camera" alt="Omnidirectional Camera by Davide Scaramuzza on ResearchGate">ResearchGate</a>.</p>
+                
+                  <p id="ref2"><strong>[2]</strong> Computer Vision: A Reference Guide, Editors: Katsushi Ikeuchi, ISBN: 978-0-387-30771-8 (Print) 978-0-387-31439-6 (Online), Springer, April, 2014</p>
+
+                  <p id="ref3"><strong>[3]</strong> Figure 1 - <a class="reference external" href="https://commons.wikimedia.org/wiki/File:Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg">https://commons.wikimedia.org/wiki/File:Nikon_1_V1_%2B_Fisheye_FC-E9_01.jpg</a></p>
+
+                  <p id="ref4"><strong>[4]</strong> Figure 3 - <a class="reference external" href="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg">https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Ricoh_Theta_S_camera.jpg/220px-Ricoh_Theta_S_camera.jpg</a></p>
+                  
+                  <p id="ref5"><strong>[5]</strong> Omnidirectional cameras - <a class="reference external" href="https://en.wikipedia.org/wiki/Omnidirectional_camera">https://en.wikipedia.org/wiki/Omnidirectional_camera</a></p>
+                </div>
+              </div>
+            <div class="section" id="id1">
+            <h2><a class="reference external" href="index.html">Back to home page</a><a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h2>
+            </div>
+          </div>
         </div>
       </div>
+      <footer>
+        <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+          <a href="Examples.html" class="btn btn-neutral float-right" title="Example for users to understand how to use the library" accesskey="n" rel="next">Next <span class="fa fa-arrow-circle-right"></span></a>
+          <a href="index.html" class="btn btn-neutral float-left" title="Welcome to OmniCV Documentation" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> Previous</a>
+        </div>
 
-    </section>
+        <hr/>
 
+        <div role="contentinfo">
+          <p>
+              &copy; Copyright 2020, Kaustubh Sadekar, Leena Vachhani, Abhishek Gupta
+          </p>
+        </div>
+        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>. 
+      </footer>
+
+    </div>
   </div>
-  
 
+</section>
 
+</div>
   <script type="text/javascript">
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable(true);
       });
   </script>
-
-  
-  
-    
-   
-
 </body>
 </html>


### PR DESCRIPTION
I fixed the references in the HTML since [1] contained 2 papers and [2] and [5] were duplicates. 
Thus, I split [1] into [1] and [2] and redirected the previous [2] into [5].

If this page is automatically generated, you may want to fix the source.